### PR TITLE
internal: check deps as part of vet.sh

### DIFF
--- a/internal/kokoro/vet.sh
+++ b/internal/kokoro/vet.sh
@@ -16,12 +16,17 @@ fi
 
 pwd
 
+# Fail if a dependency was added without the necessary go.mod/go.sum change
+# being part of the commit.
+GO111MODULE=on go mod tidy
+git diff go.mod | tee /dev/stderr | (! read)
+git diff go.sum | tee /dev/stderr | (! read)
+
 try3() { eval "$*" || eval "$*" || eval "$*"; }
 
 try3 go get -u \
   golang.org/x/lint/golint \
   golang.org/x/tools/cmd/goimports \
-  golang.org/x/lint/golint \
   honnef.co/go/tools/cmd/staticcheck
 
 # Look at all .go files (ignoring .pb.go files) and make sure they have a Copyright. Fail if any don't.


### PR DESCRIPTION
While we're in the $GOPATH transitionary period, a dependency could
accidentally find its way into our require statements without being codified in
go.mod/go.sum. This CL makes our CI check for such a case, and exit 1 if it
detects it.