### PR TITLE
manually generate distribution.pb.go

### DIFF
--- a/googleapis/api/distribution/distribution.pb.go
+++ b/googleapis/api/distribution/distribution.pb.go
@@ -6,7 +6,8 @@ package distribution // import "google.golang.org/genproto/googleapis/api/distri
 import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
-import _ "google.golang.org/genproto/googleapis/api/annotations"
+import any "github.com/golang/protobuf/ptypes/any"
+import timestamp "github.com/golang/protobuf/ptypes/timestamp"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -19,29 +20,30 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-// Distribution contains summary statistics for a population of values and,
-// optionally, a histogram representing the distribution of those values across
-// a specified set of histogram buckets.
+// `Distribution` contains summary statistics for a population of values. It
+// optionally contains a histogram representing the distribution of those values
+// across a set of buckets.
 //
 // The summary statistics are the count, mean, sum of the squared deviation from
 // the mean, the minimum, and the maximum of the set of population of values.
-//
 // The histogram is based on a sequence of buckets and gives a count of values
-// that fall into each bucket.  The boundaries of the buckets are given either
-// explicitly or by specifying parameters for a method of computing them
-// (buckets of fixed width or buckets of exponentially increasing width).
+// that fall into each bucket. The boundaries of the buckets are given either
+// explicitly or by formulas for buckets of fixed or exponentially increasing
+// widths.
 //
 // Although it is not forbidden, it is generally a bad idea to include
 // non-finite values (infinities or NaNs) in the population of values, as this
 // will render the `mean` and `sum_of_squared_deviation` fields meaningless.
 type Distribution struct {
-	// The number of values in the population. Must be non-negative.
+	// The number of values in the population. Must be non-negative. This value
+	// must equal the sum of the values in `bucket_counts` if a histogram is
+	// provided.
 	Count int64 `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`
 	// The arithmetic mean of the values in the population. If `count` is zero
 	// then this field must be zero.
 	Mean float64 `protobuf:"fixed64,2,opt,name=mean,proto3" json:"mean,omitempty"`
 	// The sum of squared deviations from the mean of the values in the
-	// population.  For values x_i this is:
+	// population. For values x_i this is:
 	//
 	//     Sum[i=1..n]((x_i - mean)^2)
 	//
@@ -53,31 +55,37 @@ type Distribution struct {
 	// If specified, contains the range of the population values. The field
 	// must not be present if the `count` is zero.
 	Range *Distribution_Range `protobuf:"bytes,4,opt,name=range,proto3" json:"range,omitempty"`
-	// Defines the histogram bucket boundaries.
+	// Defines the histogram bucket boundaries. If the distribution does not
+	// contain a histogram, then omit this field.
 	BucketOptions *Distribution_BucketOptions `protobuf:"bytes,6,opt,name=bucket_options,json=bucketOptions,proto3" json:"bucket_options,omitempty"`
-	// If `bucket_options` is given, then the sum of the values in `bucket_counts`
-	// must equal the value in `count`.  If `bucket_options` is not given, no
-	// `bucket_counts` fields may be given.
+	// The number of values in each bucket of the histogram, as described in
+	// `bucket_options`. If the distribution does not have a histogram, then omit
+	// this field. If there is a histogram, then the sum of the values in
+	// `bucket_counts` must equal the value in the `count` field of the
+	// distribution.
 	//
-	// Bucket counts are given in order under the numbering scheme described
-	// above (the underflow bucket has number 0; the finite buckets, if any,
-	// have numbers 1 through N-2; the overflow bucket has number N-1).
+	// If present, `bucket_counts` should contain N values, where N is the number
+	// of buckets specified in `bucket_options`. If you supply fewer than N
+	// values, the remaining values are assumed to be 0.
 	//
-	// The size of `bucket_counts` must be no greater than N as defined in
-	// `bucket_options`.
-	//
-	// Any suffix of trailing zero bucket_count fields may be omitted.
-	BucketCounts         []int64  `protobuf:"varint,7,rep,packed,name=bucket_counts,json=bucketCounts,proto3" json:"bucket_counts,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	// The order of the values in `bucket_counts` follows the bucket numbering
+	// schemes described for the three bucket types. The first value must be the
+	// count for the underflow bucket (number 0). The next N-2 values are the
+	// counts for the finite buckets (number 1 through N-2). The N'th value in
+	// `bucket_counts` is the count for the overflow bucket (number N-1).
+	BucketCounts []int64 `protobuf:"varint,7,rep,packed,name=bucket_counts,json=bucketCounts,proto3" json:"bucket_counts,omitempty"`
+	// Must be in increasing order of `value` field.
+	Exemplars            []*Distribution_Exemplar `protobuf:"bytes,10,rep,name=exemplars,proto3" json:"exemplars,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}                 `json:"-"`
+	XXX_unrecognized     []byte                   `json:"-"`
+	XXX_sizecache        int32                    `json:"-"`
 }
 
 func (m *Distribution) Reset()         { *m = Distribution{} }
 func (m *Distribution) String() string { return proto.CompactTextString(m) }
 func (*Distribution) ProtoMessage()    {}
 func (*Distribution) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_4362d2d5f4dd1b54, []int{0}
+	return fileDescriptor_distribution_56c6a1d50d474e70, []int{0}
 }
 func (m *Distribution) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution.Unmarshal(m, b)
@@ -139,6 +147,13 @@ func (m *Distribution) GetBucketCounts() []int64 {
 	return nil
 }
 
+func (m *Distribution) GetExemplars() []*Distribution_Exemplar {
+	if m != nil {
+		return m.Exemplars
+	}
+	return nil
+}
+
 // The range of the population values.
 type Distribution_Range struct {
 	// The minimum of the population values.
@@ -154,7 +169,7 @@ func (m *Distribution_Range) Reset()         { *m = Distribution_Range{} }
 func (m *Distribution_Range) String() string { return proto.CompactTextString(m) }
 func (*Distribution_Range) ProtoMessage()    {}
 func (*Distribution_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_4362d2d5f4dd1b54, []int{0, 0}
+	return fileDescriptor_distribution_56c6a1d50d474e70, []int{0, 0}
 }
 func (m *Distribution_Range) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_Range.Unmarshal(m, b)
@@ -188,29 +203,21 @@ func (m *Distribution_Range) GetMax() float64 {
 	return 0
 }
 
-// A Distribution may optionally contain a histogram of the values in the
-// population.  The histogram is given in `bucket_counts` as counts of values
-// that fall into one of a sequence of non-overlapping buckets.  The sequence
-// of buckets is described by `bucket_options`.
+// `BucketOptions` describes the bucket boundaries used to create a histogram
+// for the distribution. The buckets can be in a linear sequence, an
+// exponential sequence, or each bucket can be specified explicitly.
+// `BucketOptions` does not include the number of values in each bucket.
 //
-// A bucket specifies an inclusive lower bound and exclusive upper bound for
-// the values that are counted for that bucket.  The upper bound of a bucket
-// is strictly greater than the lower bound.
-//
-// The sequence of N buckets for a Distribution consists of an underflow
-// bucket (number 0), zero or more finite buckets (number 1 through N - 2) and
-// an overflow bucket (number N - 1).  The buckets are contiguous:  the lower
-// bound of bucket i (i > 0) is the same as the upper bound of bucket i - 1.
-// The buckets span the whole range of finite values: lower bound of the
-// underflow bucket is -infinity and the upper bound of the overflow bucket is
-// +infinity.  The finite buckets are so-called because both bounds are
-// finite.
-//
-// `BucketOptions` describes bucket boundaries in one of three ways.  Two
-// describe the boundaries by giving parameters for a formula to generate
-// boundaries and one gives the bucket boundaries explicitly.
-//
-// If `bucket_boundaries` is not given, then no `bucket_counts` may be given.
+// A bucket has an inclusive lower bound and exclusive upper bound for the
+// values that are counted for that bucket. The upper bound of a bucket must
+// be strictly greater than the lower bound. The sequence of N buckets for a
+// distribution consists of an underflow bucket (number 0), zero or more
+// finite buckets (number 1 through N - 2) and an overflow bucket (number N -
+// 1). The buckets are contiguous: the lower bound of bucket i (i > 0) is the
+// same as the upper bound of bucket i - 1. The buckets span the whole range
+// of finite values: lower bound of the underflow bucket is -infinity and the
+// upper bound of the overflow bucket is +infinity. The finite buckets are
+// so-called because both bounds are finite.
 type Distribution_BucketOptions struct {
 	// Exactly one of these three fields must be set.
 	//
@@ -228,7 +235,7 @@ func (m *Distribution_BucketOptions) Reset()         { *m = Distribution_BucketO
 func (m *Distribution_BucketOptions) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions) ProtoMessage()    {}
 func (*Distribution_BucketOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_4362d2d5f4dd1b54, []int{0, 1}
+	return fileDescriptor_distribution_56c6a1d50d474e70, []int{0, 1}
 }
 func (m *Distribution_BucketOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions.Unmarshal(m, b)
@@ -391,12 +398,12 @@ func _Distribution_BucketOptions_OneofSizer(msg proto.Message) (n int) {
 	return n
 }
 
-// Specify a sequence of buckets that all have the same width (except
-// overflow and underflow).  Each bucket represents a constant absolute
-// uncertainty on the specific value in the bucket.
+// Specifies a linear sequence of buckets that all have the same width
+// (except overflow and underflow). Each bucket represents a constant
+// absolute uncertainty on the specific value in the bucket.
 //
-// Defines `num_finite_buckets + 2` (= N) buckets with these boundaries for
-// bucket `i`:
+// There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
+// following boundaries:
 //
 //    Upper bound (0 <= i < N-1):     offset + (width * i).
 //    Lower bound (1 <= i < N):       offset + (width * (i - 1)).
@@ -416,7 +423,7 @@ func (m *Distribution_BucketOptions_Linear) Reset()         { *m = Distribution_
 func (m *Distribution_BucketOptions_Linear) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions_Linear) ProtoMessage()    {}
 func (*Distribution_BucketOptions_Linear) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_4362d2d5f4dd1b54, []int{0, 1, 0}
+	return fileDescriptor_distribution_56c6a1d50d474e70, []int{0, 1, 0}
 }
 func (m *Distribution_BucketOptions_Linear) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions_Linear.Unmarshal(m, b)
@@ -457,12 +464,12 @@ func (m *Distribution_BucketOptions_Linear) GetOffset() float64 {
 	return 0
 }
 
-// Specify a sequence of buckets that have a width that is proportional to
-// the value of the lower bound.  Each bucket represents a constant relative
-// uncertainty on a specific value in the bucket.
+// Specifies an exponential sequence of buckets that have a width that is
+// proportional to the value of the lower bound. Each bucket represents a
+// constant relative uncertainty on a specific value in the bucket.
 //
-// Defines `num_finite_buckets + 2` (= N) buckets with these boundaries for
-// bucket i:
+// There are `num_finite_buckets + 2` (= N) buckets. Bucket `i` has the
+// following boundaries:
 //
 //    Upper bound (0 <= i < N-1):     scale * (growth_factor ^ i).
 //    Lower bound (1 <= i < N):       scale * (growth_factor ^ (i - 1)).
@@ -484,7 +491,7 @@ func (m *Distribution_BucketOptions_Exponential) Reset() {
 func (m *Distribution_BucketOptions_Exponential) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions_Exponential) ProtoMessage()    {}
 func (*Distribution_BucketOptions_Exponential) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_4362d2d5f4dd1b54, []int{0, 1, 1}
+	return fileDescriptor_distribution_56c6a1d50d474e70, []int{0, 1, 1}
 }
 func (m *Distribution_BucketOptions_Exponential) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions_Exponential.Unmarshal(m, b)
@@ -525,17 +532,17 @@ func (m *Distribution_BucketOptions_Exponential) GetScale() float64 {
 	return 0
 }
 
-// A set of buckets with arbitrary widths.
+// Specifies a set of buckets with arbitrary widths.
 //
-// Defines `size(bounds) + 1` (= N) buckets with these boundaries for
-// bucket i:
+// There are `size(bounds) + 1` (= N) buckets. Bucket `i` has the following
+// boundaries:
 //
 //    Upper bound (0 <= i < N-1):     bounds[i]
 //    Lower bound (1 <= i < N);       bounds[i - 1]
 //
-// There must be at least one element in `bounds`.  If `bounds` has only one
-// element, there are no finite buckets, and that single element is the
-// common boundary of the overflow and underflow buckets.
+// The `bounds` field must contain at least one element. If `bounds` has
+// only one element, then there are no finite buckets, and that single
+// element is the common boundary of the overflow and underflow buckets.
 type Distribution_BucketOptions_Explicit struct {
 	// The values must be monotonically increasing.
 	Bounds               []float64 `protobuf:"fixed64,1,rep,packed,name=bounds,proto3" json:"bounds,omitempty"`
@@ -548,7 +555,7 @@ func (m *Distribution_BucketOptions_Explicit) Reset()         { *m = Distributio
 func (m *Distribution_BucketOptions_Explicit) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions_Explicit) ProtoMessage()    {}
 func (*Distribution_BucketOptions_Explicit) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_4362d2d5f4dd1b54, []int{0, 1, 2}
+	return fileDescriptor_distribution_56c6a1d50d474e70, []int{0, 1, 2}
 }
 func (m *Distribution_BucketOptions_Explicit) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions_Explicit.Unmarshal(m, b)
@@ -575,6 +582,79 @@ func (m *Distribution_BucketOptions_Explicit) GetBounds() []float64 {
 	return nil
 }
 
+// Exemplars are example points that may be used to annotate aggregated
+// distribution values. They are metadata that gives information about a
+// particular value added to a Distribution bucket, such as a trace ID that
+// was active when a value was added. They may contain further information,
+// such as a example values and timestamps, origin, etc.
+type Distribution_Exemplar struct {
+	// Value of the exemplar point. This value determines to which bucket the
+	// exemplar belongs.
+	Value float64 `protobuf:"fixed64,1,opt,name=value,proto3" json:"value,omitempty"`
+	// The observation (sampling) time of the above value.
+	Timestamp *timestamp.Timestamp `protobuf:"bytes,2,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// Contextual information about the example value. Examples are:
+	//
+	//   Trace ID: type.googleapis.com/google.devtools.cloudtrace.v1.Trace
+	//
+	//   Literal string: type.googleapis.com/google.protobuf.StringValue
+	//
+	//   Labels dropped during aggregation:
+	//     type.googleapis.com/google.monitoring.v3.DroppedLabels
+	//
+	// There may be only a single attachment of any given message type in a
+	// single exemplar, and this is enforced by the system.
+	Attachments          []*any.Any `protobuf:"bytes,3,rep,name=attachments,proto3" json:"attachments,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}   `json:"-"`
+	XXX_unrecognized     []byte     `json:"-"`
+	XXX_sizecache        int32      `json:"-"`
+}
+
+func (m *Distribution_Exemplar) Reset()         { *m = Distribution_Exemplar{} }
+func (m *Distribution_Exemplar) String() string { return proto.CompactTextString(m) }
+func (*Distribution_Exemplar) ProtoMessage()    {}
+func (*Distribution_Exemplar) Descriptor() ([]byte, []int) {
+	return fileDescriptor_distribution_56c6a1d50d474e70, []int{0, 2}
+}
+func (m *Distribution_Exemplar) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Distribution_Exemplar.Unmarshal(m, b)
+}
+func (m *Distribution_Exemplar) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Distribution_Exemplar.Marshal(b, m, deterministic)
+}
+func (dst *Distribution_Exemplar) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Distribution_Exemplar.Merge(dst, src)
+}
+func (m *Distribution_Exemplar) XXX_Size() int {
+	return xxx_messageInfo_Distribution_Exemplar.Size(m)
+}
+func (m *Distribution_Exemplar) XXX_DiscardUnknown() {
+	xxx_messageInfo_Distribution_Exemplar.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Distribution_Exemplar proto.InternalMessageInfo
+
+func (m *Distribution_Exemplar) GetValue() float64 {
+	if m != nil {
+		return m.Value
+	}
+	return 0
+}
+
+func (m *Distribution_Exemplar) GetTimestamp() *timestamp.Timestamp {
+	if m != nil {
+		return m.Timestamp
+	}
+	return nil
+}
+
+func (m *Distribution_Exemplar) GetAttachments() []*any.Any {
+	if m != nil {
+		return m.Attachments
+	}
+	return nil
+}
+
 func init() {
 	proto.RegisterType((*Distribution)(nil), "google.api.Distribution")
 	proto.RegisterType((*Distribution_Range)(nil), "google.api.Distribution.Range")
@@ -582,45 +662,53 @@ func init() {
 	proto.RegisterType((*Distribution_BucketOptions_Linear)(nil), "google.api.Distribution.BucketOptions.Linear")
 	proto.RegisterType((*Distribution_BucketOptions_Exponential)(nil), "google.api.Distribution.BucketOptions.Exponential")
 	proto.RegisterType((*Distribution_BucketOptions_Explicit)(nil), "google.api.Distribution.BucketOptions.Explicit")
+	proto.RegisterType((*Distribution_Exemplar)(nil), "google.api.Distribution.Exemplar")
 }
 
 func init() {
-	proto.RegisterFile("google/api/distribution.proto", fileDescriptor_distribution_4362d2d5f4dd1b54)
+	proto.RegisterFile("google/api/distribution.proto", fileDescriptor_distribution_56c6a1d50d474e70)
 }
 
-var fileDescriptor_distribution_4362d2d5f4dd1b54 = []byte{
-	// 522 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0x5d, 0x6b, 0xd4, 0x40,
-	0x14, 0xdd, 0x34, 0xfb, 0xa1, 0x77, 0x3f, 0x5c, 0xc7, 0x2a, 0x21, 0xa8, 0x2c, 0x2d, 0xc8, 0x82,
-	0x9a, 0x85, 0x55, 0xf0, 0xc1, 0xb7, 0x6d, 0x2d, 0xfb, 0xa0, 0xb4, 0x8c, 0xe0, 0x83, 0x08, 0x61,
-	0x36, 0x99, 0xa4, 0xa3, 0xc9, 0x4c, 0xcc, 0x4c, 0xda, 0xfd, 0x01, 0xfe, 0x29, 0xff, 0x9d, 0xe4,
-	0x4e, 0xb6, 0x4d, 0x11, 0x61, 0x7d, 0x9b, 0x73, 0xef, 0x99, 0x73, 0xce, 0xbd, 0x64, 0x02, 0xcf,
-	0x52, 0xa5, 0xd2, 0x8c, 0x2f, 0x58, 0x21, 0x16, 0xb1, 0xd0, 0xa6, 0x14, 0x9b, 0xca, 0x08, 0x25,
-	0x83, 0xa2, 0x54, 0x46, 0x11, 0xb0, 0xed, 0x80, 0x15, 0xc2, 0x7f, 0xda, 0xa2, 0x32, 0x29, 0x95,
-	0x61, 0x35, 0x51, 0x5b, 0xe6, 0xd1, 0xaf, 0x01, 0x8c, 0x4e, 0x5b, 0x02, 0xe4, 0x10, 0x7a, 0x91,
-	0xaa, 0xa4, 0xf1, 0x9c, 0x99, 0x33, 0x77, 0xa9, 0x05, 0x84, 0x40, 0x37, 0xe7, 0x4c, 0x7a, 0x07,
-	0x33, 0x67, 0xee, 0x50, 0x3c, 0x93, 0x77, 0xe0, 0xe9, 0x2a, 0x0f, 0x55, 0x12, 0xea, 0x9f, 0x15,
-	0x2b, 0x79, 0x1c, 0xc6, 0xfc, 0x4a, 0xa0, 0xba, 0xe7, 0x22, 0xef, 0xb1, 0xae, 0xf2, 0xf3, 0xe4,
-	0xb3, 0xed, 0x9e, 0xee, 0x9a, 0xe4, 0x2d, 0xf4, 0x4a, 0x26, 0x53, 0xee, 0x75, 0x67, 0xce, 0x7c,
-	0xb8, 0x7c, 0x1e, 0xdc, 0xa6, 0x0d, 0xda, 0x59, 0x02, 0x5a, 0xb3, 0xa8, 0x25, 0x93, 0x4f, 0x30,
-	0xd9, 0x54, 0xd1, 0x0f, 0x6e, 0x42, 0x55, 0xe0, 0x04, 0x5e, 0x1f, 0xaf, 0xbf, 0xf8, 0xe7, 0xf5,
-	0x15, 0xd2, 0xcf, 0x2d, 0x9b, 0x8e, 0x37, 0x6d, 0x48, 0x8e, 0xa1, 0x29, 0x84, 0x38, 0xa1, 0xf6,
-	0x06, 0x33, 0x77, 0xee, 0xd2, 0x91, 0x2d, 0x9e, 0x60, 0xcd, 0x7f, 0x09, 0x3d, 0xcc, 0x40, 0xa6,
-	0xe0, 0xe6, 0x42, 0xe2, 0x4e, 0x1c, 0x5a, 0x1f, 0xb1, 0xc2, 0xb6, 0xcd, 0x42, 0xea, 0xa3, 0xff,
-	0xbb, 0x0b, 0xe3, 0x3b, 0x96, 0xe4, 0x0b, 0x4c, 0x32, 0x21, 0x39, 0x2b, 0x43, 0xab, 0xaa, 0x51,
-	0x60, 0xb8, 0x7c, 0xbd, 0x5f, 0xe4, 0xe0, 0x23, 0x5e, 0x5e, 0x77, 0xe8, 0xd8, 0xca, 0xd8, 0xae,
-	0x26, 0x1c, 0x1e, 0xf1, 0x6d, 0xa1, 0x24, 0x97, 0x46, 0xb0, 0xec, 0x46, 0xfc, 0x00, 0xc5, 0x97,
-	0x7b, 0x8a, 0x7f, 0xb8, 0x55, 0x58, 0x77, 0x28, 0x69, 0x09, 0xee, 0x6c, 0xbe, 0xc1, 0x94, 0x6f,
-	0x8b, 0x4c, 0x44, 0xc2, 0xdc, 0x78, 0xb8, 0xe8, 0xb1, 0xd8, 0xdf, 0x03, 0xaf, 0xaf, 0x3b, 0xf4,
-	0xc1, 0x4e, 0xaa, 0x51, 0xf7, 0x63, 0xe8, 0xdb, 0xf9, 0xc8, 0x2b, 0x20, 0xb2, 0xca, 0xc3, 0x44,
-	0x48, 0x61, 0xf8, 0x9d, 0x55, 0xf5, 0xe8, 0x54, 0x56, 0xf9, 0x19, 0x36, 0x76, 0xa9, 0x0e, 0xa1,
-	0x77, 0x2d, 0x62, 0x73, 0xd9, 0xac, 0xde, 0x02, 0xf2, 0x04, 0xfa, 0x2a, 0x49, 0x34, 0x37, 0xcd,
-	0xa7, 0xd7, 0x20, 0xff, 0x0a, 0x86, 0xad, 0x41, 0xff, 0xd3, 0xea, 0x18, 0xc6, 0x69, 0xa9, 0xae,
-	0xcd, 0x65, 0x98, 0xb0, 0xc8, 0xa8, 0xb2, 0xb1, 0x1c, 0xd9, 0xe2, 0x19, 0xd6, 0xea, 0x3c, 0x3a,
-	0x62, 0x19, 0x6f, 0x8c, 0x2d, 0xf0, 0x8f, 0xe0, 0xde, 0x6e, 0xf8, 0x3a, 0xdb, 0x46, 0x55, 0x32,
-	0xae, 0x8d, 0xdc, 0x3a, 0x9b, 0x45, 0xab, 0xfb, 0x30, 0x68, 0x3e, 0xe5, 0xd5, 0x77, 0x98, 0x44,
-	0x2a, 0x6f, 0x6d, 0x75, 0xf5, 0xb0, 0xbd, 0xd6, 0x8b, 0xfa, 0xad, 0x5e, 0x38, 0x5f, 0x4f, 0x1a,
-	0x42, 0xaa, 0x32, 0x26, 0xd3, 0x40, 0x95, 0xe9, 0x22, 0xe5, 0x12, 0x5f, 0xf2, 0xc2, 0xb6, 0x58,
-	0x21, 0xf4, 0x5f, 0x7f, 0x85, 0xf7, 0x6d, 0xb0, 0xe9, 0x23, 0xff, 0xcd, 0x9f, 0x00, 0x00, 0x00,
-	0xff, 0xff, 0x62, 0xb4, 0xef, 0x6b, 0x44, 0x04, 0x00, 0x00,
+var fileDescriptor_distribution_56c6a1d50d474e70 = []byte{
+	// 631 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xed, 0x6a, 0xd4, 0x40,
+	0x14, 0x6d, 0x9a, 0xdd, 0x6d, 0x7b, 0xb7, 0x5b, 0xeb, 0x58, 0x25, 0x06, 0xd4, 0xb5, 0x05, 0x59,
+	0x50, 0xb3, 0xb0, 0x8a, 0x0a, 0xfe, 0x90, 0x6e, 0x3f, 0xac, 0xa0, 0xb4, 0x8c, 0xe2, 0x0f, 0x11,
+	0xc2, 0x6c, 0x76, 0x92, 0x0e, 0x26, 0x33, 0x69, 0x32, 0x69, 0xb7, 0xaf, 0xe1, 0x23, 0xf8, 0x16,
+	0xbe, 0x8a, 0x4f, 0x23, 0xf3, 0x91, 0x6e, 0x6a, 0x29, 0xd4, 0x7f, 0xb9, 0xf7, 0x9c, 0x7b, 0xce,
+	0xbd, 0x73, 0x67, 0x02, 0x0f, 0x12, 0x21, 0x92, 0x94, 0x0e, 0x49, 0xce, 0x86, 0x53, 0x56, 0xca,
+	0x82, 0x4d, 0x2a, 0xc9, 0x04, 0x0f, 0xf2, 0x42, 0x48, 0x81, 0xc0, 0xc0, 0x01, 0xc9, 0x99, 0x7f,
+	0xdf, 0x52, 0x35, 0x32, 0xa9, 0xe2, 0x21, 0xe1, 0xe7, 0x86, 0xe6, 0x3f, 0xfa, 0x17, 0x92, 0x2c,
+	0xa3, 0xa5, 0x24, 0x59, 0x6e, 0x08, 0x9b, 0x7f, 0x96, 0x61, 0x75, 0xb7, 0x21, 0x8f, 0x36, 0xa0,
+	0x1d, 0x89, 0x8a, 0x4b, 0xcf, 0xe9, 0x3b, 0x03, 0x17, 0x9b, 0x00, 0x21, 0x68, 0x65, 0x94, 0x70,
+	0x6f, 0xb1, 0xef, 0x0c, 0x1c, 0xac, 0xbf, 0xd1, 0x6b, 0xf0, 0xca, 0x2a, 0x0b, 0x45, 0x1c, 0x96,
+	0x27, 0x15, 0x29, 0xe8, 0x34, 0x9c, 0xd2, 0x53, 0x46, 0x94, 0x8a, 0xe7, 0x6a, 0xde, 0xdd, 0xb2,
+	0xca, 0x0e, 0xe3, 0xcf, 0x06, 0xdd, 0xad, 0x41, 0xf4, 0x12, 0xda, 0x05, 0xe1, 0x09, 0xf5, 0x5a,
+	0x7d, 0x67, 0xd0, 0x1d, 0x3d, 0x0c, 0xe6, 0xb3, 0x04, 0xcd, 0x5e, 0x02, 0xac, 0x58, 0xd8, 0x90,
+	0xd1, 0x27, 0x58, 0x9b, 0x54, 0xd1, 0x0f, 0x2a, 0x43, 0x91, 0x2b, 0xb4, 0xf4, 0x3a, 0xba, 0xfc,
+	0xc9, 0xb5, 0xe5, 0x63, 0x4d, 0x3f, 0x34, 0x6c, 0xdc, 0x9b, 0x34, 0x43, 0xb4, 0x05, 0x36, 0x11,
+	0xea, 0x09, 0x4b, 0x6f, 0xa9, 0xef, 0x0e, 0x5c, 0xbc, 0x6a, 0x92, 0x3b, 0x3a, 0x87, 0xde, 0xc1,
+	0x0a, 0x9d, 0xd1, 0x2c, 0x4f, 0x49, 0x51, 0x7a, 0xd0, 0x77, 0x07, 0xdd, 0xd1, 0xe3, 0x6b, 0xed,
+	0xf6, 0x2c, 0x13, 0xcf, 0x6b, 0xfc, 0xa7, 0xd0, 0xd6, 0x43, 0xa0, 0x75, 0x70, 0x33, 0xc6, 0xf5,
+	0xa1, 0x3a, 0x58, 0x7d, 0xea, 0x0c, 0x99, 0xd9, 0x13, 0x55, 0x9f, 0xfe, 0xef, 0x16, 0xf4, 0x2e,
+	0xf5, 0x8c, 0xbe, 0xc2, 0x5a, 0xca, 0x38, 0x25, 0x45, 0x68, 0xda, 0x2a, 0xb5, 0x40, 0x77, 0xf4,
+	0xfc, 0x66, 0x33, 0x07, 0x1f, 0x75, 0xf1, 0xc1, 0x02, 0xee, 0x19, 0x19, 0x83, 0x96, 0x88, 0xc2,
+	0x1d, 0x3a, 0xcb, 0x05, 0xa7, 0x5c, 0x32, 0x92, 0x5e, 0x88, 0x2f, 0x6a, 0xf1, 0xd1, 0x0d, 0xc5,
+	0xf7, 0xe6, 0x0a, 0x07, 0x0b, 0x18, 0x35, 0x04, 0x6b, 0x9b, 0xef, 0xb0, 0x4e, 0x67, 0x79, 0xca,
+	0x22, 0x26, 0x2f, 0x3c, 0x5c, 0xed, 0x31, 0xbc, 0xb9, 0x87, 0x2e, 0x3f, 0x58, 0xc0, 0xb7, 0x6a,
+	0x29, 0xab, 0xee, 0x4f, 0xa1, 0x63, 0xe6, 0x43, 0xcf, 0x00, 0xf1, 0x2a, 0x0b, 0x63, 0xc6, 0x99,
+	0xa4, 0x97, 0x8e, 0xaa, 0x8d, 0xd7, 0x79, 0x95, 0xed, 0x6b, 0xa0, 0xee, 0x6a, 0x03, 0xda, 0x67,
+	0x6c, 0x2a, 0x8f, 0xed, 0xd1, 0x9b, 0x00, 0xdd, 0x83, 0x8e, 0x88, 0xe3, 0x92, 0x4a, 0x7b, 0x77,
+	0x6d, 0xe4, 0x9f, 0x42, 0xb7, 0x31, 0xe8, 0x7f, 0x5a, 0x6d, 0x41, 0x2f, 0x29, 0xc4, 0x99, 0x3c,
+	0x0e, 0x63, 0x12, 0x49, 0x51, 0x58, 0xcb, 0x55, 0x93, 0xdc, 0xd7, 0x39, 0xd5, 0x4f, 0x19, 0x91,
+	0x94, 0x5a, 0x63, 0x13, 0xf8, 0x9b, 0xb0, 0x5c, 0x0f, 0xaf, 0x7a, 0x9b, 0x88, 0x8a, 0x4f, 0x95,
+	0x91, 0xab, 0x7a, 0x33, 0xd1, 0x78, 0x05, 0x96, 0xec, 0x5b, 0xf0, 0x7f, 0x3a, 0x8a, 0x6f, 0xae,
+	0x9d, 0x52, 0x3c, 0x25, 0x69, 0x45, 0xed, 0x75, 0x33, 0x01, 0x7a, 0x03, 0x2b, 0x17, 0xaf, 0xdf,
+	0xae, 0xda, 0xaf, 0xd7, 0x50, 0xff, 0x1f, 0x82, 0x2f, 0x35, 0x03, 0xcf, 0xc9, 0xe8, 0x15, 0x74,
+	0x89, 0x94, 0x24, 0x3a, 0xce, 0x28, 0xd7, 0x2b, 0x54, 0x0f, 0x61, 0xe3, 0x4a, 0xed, 0x36, 0x3f,
+	0xc7, 0x4d, 0xe2, 0xf8, 0x04, 0xd6, 0x22, 0x91, 0x35, 0x56, 0x3d, 0xbe, 0xdd, 0xdc, 0xf5, 0x91,
+	0x2a, 0x3c, 0x72, 0xbe, 0xed, 0x58, 0x42, 0x22, 0x52, 0xc2, 0x93, 0x40, 0x14, 0xc9, 0x30, 0xa1,
+	0x5c, 0xcb, 0x0e, 0x0d, 0x44, 0x72, 0x56, 0x5e, 0xf9, 0x13, 0xbe, 0x6d, 0x06, 0xbf, 0x16, 0x5b,
+	0xef, 0xb7, 0x8f, 0x3e, 0x4c, 0x3a, 0xba, 0xec, 0xc5, 0xdf, 0x00, 0x00, 0x00, 0xff, 0xff, 0x89,
+	0xf1, 0xc2, 0x23, 0x3f, 0x05, 0x00, 0x00,
 }


### PR DESCRIPTION
There are two definitions for distribution.proto: one in googleapis/googleapis,
and another in googleapis/api-common-protos. The canonical source is supposed
to be in the latter but is actually in the former. I've manually deleted
the distribution.proto in api-commons-proto on my local system and re-run
regen.sh to force the update in this PR.