### PR TITLE
internal: improve CI/CD scripts

### DIFF
--- a/internal/kokoro/check_incompat_changes.sh
+++ b/internal/kokoro/check_incompat_changes.sh
@@ -3,10 +3,8 @@
 # Display commands being run
 set -x
 
-# Only run apidiff checks on go1.11 (we only need it once).
-# TODO(deklerk) We should pass an environment variable from kokoro to decide
-# this logic instead.
-if [[ `go version` != *"go1.11"* ]]; then
+# Only run apidiff checks on go1.12 (we only need it once).
+if [[ `go version` != *"go1.12"* ]]; then
     exit 0
 fi
 
@@ -14,9 +12,7 @@ if git log -1 | grep BREAKING_CHANGE_ACCEPTABLE; then
   exit 0
 fi
 
-try3() { eval "$*" || eval "$*" || eval "$*"; }
-
-try3 go get -u golang.org/x/exp/cmd/apidiff
+go install golang.org/x/exp/cmd/apidiff
 
 # We compare against master@HEAD. This is unfortunate in some cases: if you're
 # working on an out-of-date branch, and master gets some new feature (that has

--- a/internal/kokoro/test.sh
+++ b/internal/kokoro/test.sh
@@ -22,8 +22,20 @@ git clone . $GENPROTO_HOME
 cd $GENPROTO_HOME
 
 try3() { eval "$*" || eval "$*" || eval "$*"; }
-try3 go get -v -t ./...
 
+download_deps() {
+    if [[ `go version` == *"go1.11"* ]] || [[ `go version` == *"go1.12"* ]]; then
+        export GO111MODULE=on
+        # All packages, including +build tools, are fetched.
+        try3 go mod download
+    else
+        # Because we don't provide -tags tools, the +build tools
+        # dependencies aren't fetched.
+        try3 go get -v -t ./...
+    fi
+}
+
+download_deps
 ./internal/kokoro/vet.sh
 ./internal/kokoro/check_incompat_changes.sh
 

--- a/internal/kokoro/vet.sh
+++ b/internal/kokoro/vet.sh
@@ -6,28 +6,24 @@ set -eo pipefail
 # Display commands being run
 set -x
 
-# Only run the linter on go1.11, since it needs type aliases (and we only care
+# Only run the linter on go1.12, since it needs type aliases (and we only care
 # about its output once).
-# TODO(deklerk) We should pass an environment variable from kokoro to decide
-# this logic instead.
-if [[ `go version` != *"go1.11"* ]]; then
+if [[ `go version` != *"go1.12"* ]]; then
     exit 0
 fi
 
-pwd
+go install \
+  github.com/golang/protobuf/protoc-gen-go \
+  golang.org/x/tools/cmd/goimports
 
 # Fail if a dependency was added without the necessary go.mod/go.sum change
 # being part of the commit.
-GO111MODULE=on go mod tidy
+go mod tidy
 git diff go.mod | tee /dev/stderr | (! read)
 git diff go.sum | tee /dev/stderr | (! read)
 
-try3() { eval "$*" || eval "$*" || eval "$*"; }
-
-try3 go get -u \
-  golang.org/x/lint/golint \
-  golang.org/x/tools/cmd/goimports \
-  honnef.co/go/tools/cmd/staticcheck
+# Easier to debug CI.
+pwd
 
 # Look at all .go files (ignoring .pb.go files) and make sure they have a Copyright. Fail if any don't.
 git ls-files "*[^.pb].go" | xargs grep -L "\(Copyright [0-9]\{4,\}\)" 2>&1 | tee /dev/stderr | (! read)


### PR DESCRIPTION
- Use go mod tidy to check if deps were added without being added to go.mod.
- Use go mod download to download deps instead of go get.
- Use GO111MODULE=on everywhere applicable.
- Switch to being 1.12 aware.