### PR TITLE
manually regen distribution.proto and backend.proto

### DIFF
--- a/googleapis/api/distribution/distribution.pb.go
+++ b/googleapis/api/distribution/distribution.pb.go
@@ -85,7 +85,7 @@ func (m *Distribution) Reset()         { *m = Distribution{} }
 func (m *Distribution) String() string { return proto.CompactTextString(m) }
 func (*Distribution) ProtoMessage()    {}
 func (*Distribution) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_445cf39de42d9ede, []int{0}
+	return fileDescriptor_distribution_ff64d440f86eff03, []int{0}
 }
 func (m *Distribution) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution.Unmarshal(m, b)
@@ -169,7 +169,7 @@ func (m *Distribution_Range) Reset()         { *m = Distribution_Range{} }
 func (m *Distribution_Range) String() string { return proto.CompactTextString(m) }
 func (*Distribution_Range) ProtoMessage()    {}
 func (*Distribution_Range) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_445cf39de42d9ede, []int{0, 0}
+	return fileDescriptor_distribution_ff64d440f86eff03, []int{0, 0}
 }
 func (m *Distribution_Range) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_Range.Unmarshal(m, b)
@@ -235,7 +235,7 @@ func (m *Distribution_BucketOptions) Reset()         { *m = Distribution_BucketO
 func (m *Distribution_BucketOptions) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions) ProtoMessage()    {}
 func (*Distribution_BucketOptions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_445cf39de42d9ede, []int{0, 1}
+	return fileDescriptor_distribution_ff64d440f86eff03, []int{0, 1}
 }
 func (m *Distribution_BucketOptions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions.Unmarshal(m, b)
@@ -423,7 +423,7 @@ func (m *Distribution_BucketOptions_Linear) Reset()         { *m = Distribution_
 func (m *Distribution_BucketOptions_Linear) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions_Linear) ProtoMessage()    {}
 func (*Distribution_BucketOptions_Linear) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_445cf39de42d9ede, []int{0, 1, 0}
+	return fileDescriptor_distribution_ff64d440f86eff03, []int{0, 1, 0}
 }
 func (m *Distribution_BucketOptions_Linear) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions_Linear.Unmarshal(m, b)
@@ -491,7 +491,7 @@ func (m *Distribution_BucketOptions_Exponential) Reset() {
 func (m *Distribution_BucketOptions_Exponential) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions_Exponential) ProtoMessage()    {}
 func (*Distribution_BucketOptions_Exponential) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_445cf39de42d9ede, []int{0, 1, 1}
+	return fileDescriptor_distribution_ff64d440f86eff03, []int{0, 1, 1}
 }
 func (m *Distribution_BucketOptions_Exponential) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions_Exponential.Unmarshal(m, b)
@@ -555,7 +555,7 @@ func (m *Distribution_BucketOptions_Explicit) Reset()         { *m = Distributio
 func (m *Distribution_BucketOptions_Explicit) String() string { return proto.CompactTextString(m) }
 func (*Distribution_BucketOptions_Explicit) ProtoMessage()    {}
 func (*Distribution_BucketOptions_Explicit) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_445cf39de42d9ede, []int{0, 1, 2}
+	return fileDescriptor_distribution_ff64d440f86eff03, []int{0, 1, 2}
 }
 func (m *Distribution_BucketOptions_Explicit) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_BucketOptions_Explicit.Unmarshal(m, b)
@@ -614,7 +614,7 @@ func (m *Distribution_Exemplar) Reset()         { *m = Distribution_Exemplar{} }
 func (m *Distribution_Exemplar) String() string { return proto.CompactTextString(m) }
 func (*Distribution_Exemplar) ProtoMessage()    {}
 func (*Distribution_Exemplar) Descriptor() ([]byte, []int) {
-	return fileDescriptor_distribution_445cf39de42d9ede, []int{0, 2}
+	return fileDescriptor_distribution_ff64d440f86eff03, []int{0, 2}
 }
 func (m *Distribution_Exemplar) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Distribution_Exemplar.Unmarshal(m, b)
@@ -666,10 +666,10 @@ func init() {
 }
 
 func init() {
-	proto.RegisterFile("google/api/distribution.proto", fileDescriptor_distribution_445cf39de42d9ede)
+	proto.RegisterFile("google/api/distribution.proto", fileDescriptor_distribution_ff64d440f86eff03)
 }
 
-var fileDescriptor_distribution_445cf39de42d9ede = []byte{
+var fileDescriptor_distribution_ff64d440f86eff03 = []byte{
 	// 631 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x54, 0xed, 0x6a, 0xd4, 0x40,
 	0x14, 0x6d, 0x9a, 0xdd, 0x6d, 0x7b, 0xb7, 0x5b, 0xeb, 0x58, 0x25, 0x06, 0xd4, 0xb5, 0x05, 0x59,

--- a/googleapis/api/serviceconfig/backend.pb.go
+++ b/googleapis/api/serviceconfig/backend.pb.go
@@ -18,6 +18,81 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
+// Path Translation specifies how to combine the backend address with the
+// request path in order to produce the appropriate forwarding URL for the
+// request.
+//
+// Path Translation is applicable only to HTTP-based backends. Backends which
+// do not accept requests over HTTP/HTTPS should leave `path_translation`
+// unspecified.
+type BackendRule_PathTranslation int32
+
+const (
+	BackendRule_PATH_TRANSLATION_UNSPECIFIED BackendRule_PathTranslation = 0
+	// Use the backend address as-is, with no modification to the path. If the
+	// URL pattern contains variables, the variable names and values will be
+	// appended to the query string. If a query string parameter and a URL
+	// pattern variable have the same name, this may result in duplicate keys in
+	// the query string.
+	//
+	// # Examples
+	//
+	// Given the following operation config:
+	//
+	//     Method path:        /api/company/{cid}/user/{uid}
+	//     Backend address:    https://example.cloudfunctions.net/getUser
+	//
+	// Requests to the following request paths will call the backend at the
+	// translated path:
+	//
+	//     Request path: /api/company/widgetworks/user/johndoe
+	//     Translated:
+	//     https://example.cloudfunctions.net/getUser?cid=widgetworks&uid=johndoe
+	//
+	//     Request path: /api/company/widgetworks/user/johndoe?timezone=EST
+	//     Translated:
+	//     https://example.cloudfunctions.net/getUser?timezone=EST&cid=widgetworks&uid=johndoe
+	BackendRule_CONSTANT_ADDRESS BackendRule_PathTranslation = 1
+	// The request path will be appended to the backend address.
+	//
+	// # Examples
+	//
+	// Given the following operation config:
+	//
+	//     Method path:        /api/company/{cid}/user/{uid}
+	//     Backend address:    https://example.appspot.com
+	//
+	// Requests to the following request paths will call the backend at the
+	// translated path:
+	//
+	//     Request path: /api/company/widgetworks/user/johndoe
+	//     Translated:
+	//     https://example.appspot.com/api/company/widgetworks/user/johndoe
+	//
+	//     Request path: /api/company/widgetworks/user/johndoe?timezone=EST
+	//     Translated:
+	//     https://example.appspot.com/api/company/widgetworks/user/johndoe?timezone=EST
+	BackendRule_APPEND_PATH_TO_ADDRESS BackendRule_PathTranslation = 2
+)
+
+var BackendRule_PathTranslation_name = map[int32]string{
+	0: "PATH_TRANSLATION_UNSPECIFIED",
+	1: "CONSTANT_ADDRESS",
+	2: "APPEND_PATH_TO_ADDRESS",
+}
+var BackendRule_PathTranslation_value = map[string]int32{
+	"PATH_TRANSLATION_UNSPECIFIED": 0,
+	"CONSTANT_ADDRESS":             1,
+	"APPEND_PATH_TO_ADDRESS":       2,
+}
+
+func (x BackendRule_PathTranslation) String() string {
+	return proto.EnumName(BackendRule_PathTranslation_name, int32(x))
+}
+func (BackendRule_PathTranslation) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_backend_525705f4783ed271, []int{1, 0}
+}
+
 // `Backend` defines the backend configuration for a service.
 type Backend struct {
 	// A list of API backend rules that apply to individual API methods.
@@ -33,7 +108,7 @@ func (m *Backend) Reset()         { *m = Backend{} }
 func (m *Backend) String() string { return proto.CompactTextString(m) }
 func (*Backend) ProtoMessage()    {}
 func (*Backend) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backend_bb737a5d3bcbecd6, []int{0}
+	return fileDescriptor_backend_525705f4783ed271, []int{0}
 }
 func (m *Backend) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Backend.Unmarshal(m, b)
@@ -64,7 +139,8 @@ func (m *Backend) GetRules() []*BackendRule {
 type BackendRule struct {
 	// Selects the methods to which this rule applies.
 	//
-	// Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+	// Refer to [selector][google.api.DocumentationRule.selector] for syntax
+	// details.
 	Selector string `protobuf:"bytes,1,opt,name=selector,proto3" json:"selector,omitempty"`
 	// The address of the API backend.
 	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
@@ -73,17 +149,33 @@ type BackendRule struct {
 	Deadline float64 `protobuf:"fixed64,3,opt,name=deadline,proto3" json:"deadline,omitempty"`
 	// Minimum deadline in seconds needed for this method. Calls having deadline
 	// value lower than this will be rejected.
-	MinDeadline          float64  `protobuf:"fixed64,4,opt,name=min_deadline,json=minDeadline,proto3" json:"min_deadline,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	MinDeadline float64 `protobuf:"fixed64,4,opt,name=min_deadline,json=minDeadline,proto3" json:"min_deadline,omitempty"`
+	// The number of seconds to wait for the completion of a long running
+	// operation. The default is no deadline.
+	OperationDeadline float64                     `protobuf:"fixed64,5,opt,name=operation_deadline,json=operationDeadline,proto3" json:"operation_deadline,omitempty"`
+	PathTranslation   BackendRule_PathTranslation `protobuf:"varint,6,opt,name=path_translation,json=pathTranslation,proto3,enum=google.api.BackendRule_PathTranslation" json:"path_translation,omitempty"`
+	// Authentication settings used by the backend.
+	//
+	// These are typically used to provide service management functionality to
+	// a backend served on a publicly-routable URL. The `authentication`
+	// details should match the authentication behavior used by the backend.
+	//
+	// For example, specifying `jwt_audience` implies that the backend expects
+	// authentication via a JWT.
+	//
+	// Types that are valid to be assigned to Authentication:
+	//	*BackendRule_JwtAudience
+	Authentication       isBackendRule_Authentication `protobuf_oneof:"authentication"`
+	XXX_NoUnkeyedLiteral struct{}                     `json:"-"`
+	XXX_unrecognized     []byte                       `json:"-"`
+	XXX_sizecache        int32                        `json:"-"`
 }
 
 func (m *BackendRule) Reset()         { *m = BackendRule{} }
 func (m *BackendRule) String() string { return proto.CompactTextString(m) }
 func (*BackendRule) ProtoMessage()    {}
 func (*BackendRule) Descriptor() ([]byte, []int) {
-	return fileDescriptor_backend_bb737a5d3bcbecd6, []int{1}
+	return fileDescriptor_backend_525705f4783ed271, []int{1}
 }
 func (m *BackendRule) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_BackendRule.Unmarshal(m, b)
@@ -131,29 +223,129 @@ func (m *BackendRule) GetMinDeadline() float64 {
 	return 0
 }
 
+func (m *BackendRule) GetOperationDeadline() float64 {
+	if m != nil {
+		return m.OperationDeadline
+	}
+	return 0
+}
+
+func (m *BackendRule) GetPathTranslation() BackendRule_PathTranslation {
+	if m != nil {
+		return m.PathTranslation
+	}
+	return BackendRule_PATH_TRANSLATION_UNSPECIFIED
+}
+
+type isBackendRule_Authentication interface {
+	isBackendRule_Authentication()
+}
+
+type BackendRule_JwtAudience struct {
+	JwtAudience string `protobuf:"bytes,7,opt,name=jwt_audience,json=jwtAudience,proto3,oneof"`
+}
+
+func (*BackendRule_JwtAudience) isBackendRule_Authentication() {}
+
+func (m *BackendRule) GetAuthentication() isBackendRule_Authentication {
+	if m != nil {
+		return m.Authentication
+	}
+	return nil
+}
+
+func (m *BackendRule) GetJwtAudience() string {
+	if x, ok := m.GetAuthentication().(*BackendRule_JwtAudience); ok {
+		return x.JwtAudience
+	}
+	return ""
+}
+
+// XXX_OneofFuncs is for the internal use of the proto package.
+func (*BackendRule) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
+	return _BackendRule_OneofMarshaler, _BackendRule_OneofUnmarshaler, _BackendRule_OneofSizer, []interface{}{
+		(*BackendRule_JwtAudience)(nil),
+	}
+}
+
+func _BackendRule_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
+	m := msg.(*BackendRule)
+	// authentication
+	switch x := m.Authentication.(type) {
+	case *BackendRule_JwtAudience:
+		b.EncodeVarint(7<<3 | proto.WireBytes)
+		b.EncodeStringBytes(x.JwtAudience)
+	case nil:
+	default:
+		return fmt.Errorf("BackendRule.Authentication has unexpected type %T", x)
+	}
+	return nil
+}
+
+func _BackendRule_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
+	m := msg.(*BackendRule)
+	switch tag {
+	case 7: // authentication.jwt_audience
+		if wire != proto.WireBytes {
+			return true, proto.ErrInternalBadWireType
+		}
+		x, err := b.DecodeStringBytes()
+		m.Authentication = &BackendRule_JwtAudience{x}
+		return true, err
+	default:
+		return false, nil
+	}
+}
+
+func _BackendRule_OneofSizer(msg proto.Message) (n int) {
+	m := msg.(*BackendRule)
+	// authentication
+	switch x := m.Authentication.(type) {
+	case *BackendRule_JwtAudience:
+		n += 1 // tag and wire
+		n += proto.SizeVarint(uint64(len(x.JwtAudience)))
+		n += len(x.JwtAudience)
+	case nil:
+	default:
+		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
+	}
+	return n
+}
+
 func init() {
 	proto.RegisterType((*Backend)(nil), "google.api.Backend")
 	proto.RegisterType((*BackendRule)(nil), "google.api.BackendRule")
+	proto.RegisterEnum("google.api.BackendRule_PathTranslation", BackendRule_PathTranslation_name, BackendRule_PathTranslation_value)
 }
 
-func init() { proto.RegisterFile("google/api/backend.proto", fileDescriptor_backend_bb737a5d3bcbecd6) }
+func init() { proto.RegisterFile("google/api/backend.proto", fileDescriptor_backend_525705f4783ed271) }
 
-var fileDescriptor_backend_bb737a5d3bcbecd6 = []byte{
-	// 246 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x54, 0x90, 0xb1, 0x4e, 0xc3, 0x30,
-	0x10, 0x86, 0xe5, 0xb6, 0x50, 0xb8, 0x54, 0x0c, 0x59, 0xb0, 0x98, 0x42, 0xa7, 0x2c, 0x38, 0x12,
-	0x2c, 0x48, 0x4c, 0x44, 0x20, 0xc4, 0x16, 0x65, 0x64, 0x41, 0xae, 0x7d, 0x58, 0x16, 0x8e, 0x2f,
-	0xb2, 0x5b, 0x1e, 0x80, 0x47, 0xe1, 0x49, 0x51, 0x9d, 0x10, 0xda, 0xf1, 0xbb, 0xef, 0x3f, 0xe9,
-	0xee, 0x07, 0x6e, 0x88, 0x8c, 0xc3, 0x4a, 0xf6, 0xb6, 0xda, 0x48, 0xf5, 0x89, 0x5e, 0x8b, 0x3e,
-	0xd0, 0x96, 0x72, 0x18, 0x8c, 0x90, 0xbd, 0x5d, 0xdf, 0xc3, 0xb2, 0x1e, 0x64, 0x7e, 0x03, 0x27,
-	0x61, 0xe7, 0x30, 0x72, 0x56, 0xcc, 0xcb, 0xec, 0xf6, 0x52, 0xfc, 0xc7, 0xc4, 0x98, 0x69, 0x77,
-	0x0e, 0xdb, 0x21, 0xb5, 0xfe, 0x66, 0x90, 0x1d, 0x8c, 0xf3, 0x2b, 0x38, 0x8b, 0xe8, 0x50, 0x6d,
-	0x29, 0x70, 0x56, 0xb0, 0xf2, 0xbc, 0x9d, 0x38, 0xe7, 0xb0, 0x94, 0x5a, 0x07, 0x8c, 0x91, 0xcf,
-	0x92, 0xfa, 0xc3, 0xfd, 0x96, 0x46, 0xa9, 0x9d, 0xf5, 0xc8, 0xe7, 0x05, 0x2b, 0x59, 0x3b, 0x71,
-	0x7e, 0x0d, 0xab, 0xce, 0xfa, 0xf7, 0xc9, 0x2f, 0x92, 0xcf, 0x3a, 0xeb, 0x9f, 0xc6, 0x51, 0xed,
-	0xe1, 0x42, 0x51, 0x77, 0x70, 0x69, 0xbd, 0x1a, 0x6f, 0x6a, 0xf6, 0xaf, 0x36, 0xec, 0xed, 0x79,
-	0x74, 0x86, 0x9c, 0xf4, 0x46, 0x50, 0x30, 0x95, 0x41, 0x9f, 0x8a, 0xa8, 0x06, 0x25, 0x7b, 0x1b,
-	0x53, 0x4b, 0x11, 0xc3, 0x97, 0x55, 0xa8, 0xc8, 0x7f, 0x58, 0xf3, 0x70, 0x44, 0x3f, 0xb3, 0xc5,
-	0xcb, 0x63, 0xf3, 0xba, 0x39, 0x4d, 0x8b, 0x77, 0xbf, 0x01, 0x00, 0x00, 0xff, 0xff, 0x7d, 0xc3,
-	0xd8, 0x52, 0x5d, 0x01, 0x00, 0x00,
+var fileDescriptor_backend_525705f4783ed271 = []byte{
+	// 408 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x74, 0x92, 0x41, 0x6f, 0xd3, 0x30,
+	0x14, 0xc7, 0x97, 0x76, 0x5b, 0xe1, 0xb5, 0xea, 0x82, 0x85, 0x20, 0x9a, 0x38, 0x84, 0x72, 0xa0,
+	0x97, 0xa5, 0xd2, 0xb8, 0x20, 0x71, 0x4a, 0x97, 0xc0, 0x2a, 0xa1, 0x34, 0x72, 0xc2, 0x85, 0x4b,
+	0xe4, 0x25, 0x8f, 0xd4, 0x23, 0xb5, 0x23, 0xc7, 0x65, 0xdf, 0x07, 0xbe, 0x28, 0xaa, 0x93, 0x65,
+	0x2d, 0x12, 0xc7, 0xff, 0xfb, 0xfd, 0x9e, 0xad, 0xbf, 0xf4, 0xc0, 0x29, 0xa5, 0x2c, 0x2b, 0x5c,
+	0xb0, 0x9a, 0x2f, 0xee, 0x58, 0xfe, 0x13, 0x45, 0xe1, 0xd5, 0x4a, 0x6a, 0x49, 0xa0, 0x25, 0x1e,
+	0xab, 0xf9, 0xec, 0x23, 0x8c, 0x96, 0x2d, 0x24, 0x57, 0x70, 0xa6, 0x76, 0x15, 0x36, 0x8e, 0xe5,
+	0x0e, 0xe7, 0xe3, 0xeb, 0xd7, 0xde, 0x93, 0xe6, 0x75, 0x0e, 0xdd, 0x55, 0x48, 0x5b, 0x6b, 0xf6,
+	0x67, 0x08, 0xe3, 0x83, 0x31, 0xb9, 0x84, 0x67, 0x0d, 0x56, 0x98, 0x6b, 0xa9, 0x1c, 0xcb, 0xb5,
+	0xe6, 0xcf, 0x69, 0x9f, 0x89, 0x03, 0x23, 0x56, 0x14, 0x0a, 0x9b, 0xc6, 0x19, 0x18, 0xf4, 0x18,
+	0xf7, 0x5b, 0x05, 0xb2, 0xa2, 0xe2, 0x02, 0x9d, 0xa1, 0x6b, 0xcd, 0x2d, 0xda, 0x67, 0xf2, 0x16,
+	0x26, 0x5b, 0x2e, 0xb2, 0x9e, 0x9f, 0x1a, 0x3e, 0xde, 0x72, 0x11, 0x3c, 0x2a, 0x57, 0x40, 0x64,
+	0x8d, 0x8a, 0x69, 0x2e, 0x0f, 0xc4, 0x33, 0x23, 0xbe, 0xe8, 0x49, 0xaf, 0x53, 0xb0, 0x6b, 0xa6,
+	0x37, 0x99, 0x56, 0x4c, 0x34, 0x95, 0x61, 0xce, 0xb9, 0x6b, 0xcd, 0xa7, 0xd7, 0xef, 0xff, 0xd3,
+	0xd6, 0x8b, 0x99, 0xde, 0xa4, 0x4f, 0x3a, 0xbd, 0xa8, 0x8f, 0x07, 0xe4, 0x1d, 0x4c, 0xee, 0x1f,
+	0x74, 0xc6, 0x76, 0x05, 0x47, 0x91, 0xa3, 0x33, 0xda, 0x17, 0xbc, 0x3d, 0xa1, 0xe3, 0xfb, 0x07,
+	0xed, 0x77, 0xc3, 0x19, 0xc2, 0xc5, 0x3f, 0x0f, 0x11, 0x17, 0xde, 0xc4, 0x7e, 0x7a, 0x9b, 0xa5,
+	0xd4, 0x8f, 0x92, 0xaf, 0x7e, 0xba, 0x5a, 0x47, 0xd9, 0xb7, 0x28, 0x89, 0xc3, 0x9b, 0xd5, 0xe7,
+	0x55, 0x18, 0xd8, 0x27, 0xe4, 0x25, 0xd8, 0x37, 0xeb, 0x28, 0x49, 0xfd, 0x28, 0xcd, 0xfc, 0x20,
+	0xa0, 0x61, 0x92, 0xd8, 0x16, 0xb9, 0x84, 0x57, 0x7e, 0x1c, 0x87, 0x51, 0x90, 0xb5, 0xeb, 0xeb,
+	0x9e, 0x0d, 0x96, 0x36, 0x4c, 0xd9, 0x4e, 0x6f, 0x50, 0x68, 0x9e, 0x9b, 0x5f, 0x96, 0x02, 0xa6,
+	0xb9, 0xdc, 0x1e, 0x94, 0x5b, 0x4e, 0xba, 0x76, 0xf1, 0xfe, 0x16, 0x62, 0xeb, 0x7b, 0xd8, 0xb1,
+	0x52, 0x56, 0x4c, 0x94, 0x9e, 0x54, 0xe5, 0xa2, 0x44, 0x61, 0x2e, 0x65, 0xd1, 0x22, 0x56, 0xf3,
+	0xc6, 0x9c, 0x51, 0x83, 0xea, 0x17, 0xcf, 0x31, 0x97, 0xe2, 0x07, 0x2f, 0x3f, 0x1d, 0xa5, 0xdf,
+	0x83, 0xd3, 0x2f, 0x7e, 0xbc, 0xba, 0x3b, 0x37, 0x8b, 0x1f, 0xfe, 0x06, 0x00, 0x00, 0xff, 0xff,
+	0x2b, 0x64, 0x62, 0xc8, 0x7e, 0x02, 0x00, 0x00,
 }


### PR DESCRIPTION
See b/123287260. Currently backend.proto and distribution.proto live in
both googleapis/googleapis and googleapis/api-common-protos. The less
up-to-date one is being used (api-common-protos). This commit is created
by pulling down api-common-protos, deleting backend.proto and
distribution.proto, and running the generation scripts with COMMONPROTOS
set to the path of the modified api-commons-proto.