### PR TITLE
remove api-commons-proto

### DIFF
--- a/regen.sh
+++ b/regen.sh
@@ -24,7 +24,6 @@ set -e
 PKG=google.golang.org/genproto
 PROTO_REPO=https://github.com/google/protobuf
 GOOGLEAPIS_REPO=https://github.com/googleapis/googleapis
-API_COMMON_REPO=https://github.com/googleapis/api-common-protos.git
 
 function die() {
   echo 1>&2 $*
@@ -63,20 +62,12 @@ else
   apidir="$GOOGLEAPIS"
 fi
 
-if [ -z "$COMMONPROTOS" ]; then
-  commondir=$(mktemp -d -t regen-cds-common.XXXXXX)
-  git clone $API_COMMON_REPO $commondir
-  remove_dirs="$remove_dirs $commondir"
-else
-  commondir="$COMMONPROTOS"
-fi
-
 wait
 
 # Nuke everything, we'll generate them back
 rm -r googleapis/ protobuf/
 
-go run regen.go -go_out "$root/src" -pkg_prefix "$PKG" "$commondir" "$apidir" "$protodir"
+go run regen.go -go_out "$root/src" -pkg_prefix "$PKG" "$apidir" "$protodir"
 
 # Sanity check the build.
 echo 1>&2 "Checking that the libraries build..."


### PR DESCRIPTION
Currently api-commons-proto is an out-of-date subset of googleapis/googleapis.
This regen script favours api-commons-proto over googleapis/googleapis. These
combined mean that protos get updated in googleapis/googelapis but never get
generated (since we're always favouring the out-of-date api-commons-proto).

This CL removes api-commons-proto from our regen script until it stops being
an out-of-date subset.